### PR TITLE
Update AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md

### DIFF
--- a/Instructions/AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md
+++ b/Instructions/AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md
@@ -367,8 +367,6 @@
 
     - Leave the **Subscription** drop-down list entry set to its default value.
 
-    - In the **Resource group** section, select the **Use existing** option.
-
     - In the **Resource group** section, ensure that **Create new** option is selected and, in the text box below, type **AADesignLab0503-RG**.
 
     - In the **App Name** text box, type a unique name for the new Function App.


### PR DESCRIPTION
The second bullet of step 10 in the Task 1 of Exercise 3 (Deploy a Function App), was incorrect, because the next step ask to create a new Resource Group (AADesignLab0503-RG) used in this exercise.