### PR TITLE
Changing the location from eastus

### DIFF
--- a/allfiles/AZ-301T03/Module_02/LabFiles/Starter/azuredeploy.json
+++ b/allfiles/AZ-301T03/Module_02/LabFiles/Starter/azuredeploy.json
@@ -169,7 +169,7 @@
     {
       "apiVersion": "2017-08-31",
       "type": "Microsoft.ContainerService/managedClusters",
-      "location": "eastus",
+      "location": "[variables('location')]",
       "name": "[variables('kubernetesClusterName')]",
       "properties": {
         "kubernetesVersion": "[variables('kubernetesVersion')]",


### PR DESCRIPTION
The location for the managed cluster was hard-coded to use east US, now we are using the RG location