### PR TITLE
Changing image offer

### DIFF
--- a/allfiles/AZ-301T01/Module_01/LabFiles/Starter/vm-template.json
+++ b/allfiles/AZ-301T01/Module_01/LabFiles/Starter/vm-template.json
@@ -15,8 +15,8 @@
         "subnetName": "Linux",
         "imageReference": {
             "publisher": "SUSE",
-            "offer": "openSUSE-Leap",
-            "sku": "15-0",
+            "offer": "SLES",
+            "sku": "15",
             "version": "latest"
         }
     },


### PR DESCRIPTION
Began receiving error this week with previous image offer that it is unavailble. Resolved by changing to SLES v15

Deployment to resource group 'cjpjan' failed.
Additional details from the underlying API that might be helpful: At least one resource deployment operation failed. Please list deployment operations for details.