### PR TITLE
change the 'metrics-server' directory

### DIFF
--- a/Instructions/AZ-301T03_Lab_Mod02_Deploying Managed Containerized Workloads to Azure.md
+++ b/Instructions/AZ-301T03_Lab_Mod02_Deploying Managed Containerized Workloads to Azure.md
@@ -296,7 +296,7 @@
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to install **Metrics Server**:
 
     ```
-    kubectl create -f ~/metrics-server/deploy/1.8+/
+    kubectl create -f ~/metrics-server/deploy/kubernetes/
     ```
 
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to configure autoscaling for the **azure-vote-front** deployment:


### PR DESCRIPTION
the /1.8+ directory no more exists since the 1.8+ is the only kubernetes supported by the tool.