### PR TITLE
Move deployment command to current version

### DIFF
--- a/Instructions/AZ-301T01_Lab_Mod01_Securing Secrets in Azure.md
+++ b/Instructions/AZ-301T01_Lab_Mod01_Securing Secrets in Azure.md
@@ -370,7 +370,7 @@
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to deploy the Azure Resource Manager template with the specified parameters file:
 
     ```sh
-    az group deployment create --resource-group $RESOURCE_GROUP --template-file ~/vm-template.json --parameters @~/vm-template.parameters.json
+    az deployment group create --resource-group $RESOURCE_GROUP --template-file ~/vm-template.json --parameters @~/vm-template.parameters.json
     ```
 
 1. Wait for the deployment to complete before you proceed to the next task.


### PR DESCRIPTION
The az deployment command setup is changing and the old syntax causes deprecation complaints.