### PR TITLE
Case typo fixed, location name script added

### DIFF
--- a/Instructions/AZ-301T02_Lab_Mod02_Deploying Database Instances in Azure.md
+++ b/Instructions/AZ-301T02_Lab_Mod02_Deploying Database Instances in Azure.md
@@ -60,7 +60,7 @@
 
     - Leave all remaining settings with their default values.
 
-    - Click the **Review + Create** button and then click the **Create** button.
+    - Click the **Review + create** button and then click the **Create** button.
 
 1. Wait for the provisioning to complete before you proceed to the next step.
 
@@ -376,7 +376,7 @@
 
     - On the **Select Pricing Tier** blade, click **Free** and then click the **Select** button.
 
-    - Click the **Review + Create** button, review the settings then click **Create**.
+    - Click the **Review + create** button, review the settings then click **Create**.
 
 1. Wait for the provisioning to complete before you proceed to the next step.
 

--- a/Instructions/AZ-301T02_Lab_Mod03_Deploying Configuration Management solutions to Azure.md
+++ b/Instructions/AZ-301T02_Lab_Mod03_Deploying Configuration Management solutions to Azure.md
@@ -192,8 +192,12 @@
     ```sh
     RESOURCE_GROUP='AADesignLab1202-RG'
     ```
+1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all region names to choose.
 
-1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to create a variable which value designates the Azure region you will use for the deployment (replace the placeholder `<Azure region>` with the name of the Azure region to which you intend to deploy resources in this lab):
+    ```sh
+    az account list-locations --query "[].name" --output tsv
+    ```
+1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to create a variable which value designates the Azure region you will use for the deployment (replace the placeholder `<Azure region>` with the name of the Azure region from one of the list in previous **Cloud Shell** output. to which you intend to deploy resources in this lab):
 
     ```sh
     LOCATION='<Azure region>'
@@ -272,7 +276,7 @@
 
 1. Navigate back to the **LinuxAutomation** blade.
 
-1. Back on the **LinuxAutomation** blade, in the **CONFIGURATION MANAGEMENT** section, click **State configuration (DSC)**.
+1. Back on the **LinuxAutomation** blade, in the **Configuration Management** section, click **State configuration (DSC)**.
 
 1. On the **LinuxAutomation - State configuration (DSC)** blade, click the **Configurations** link.
 


### PR DESCRIPTION
- Typos in AZ-301T02 fixed
- In Task 3 in AZ-301T02_Lab_Mod03, Azure region was not clear and occurs an error if some values copied from Azure Portal such as "(US) East US". Thus, added a paragraph with an az command to list all location names of Azure regions.