### PR TITLE
Update Storage account creation

### DIFF
--- a/Instructions/AZ-301T04_Lab_Mod02_Building Azure IaaS-Based Server Applications by using ARM.md
+++ b/Instructions/AZ-301T04_Lab_Mod02_Building Azure IaaS-Based Server Applications by using ARM.md
@@ -176,10 +176,13 @@ o
 
     - In the **Performance** section, ensure that the **Standard** option is selected.
 
-
     - In the **Account kind** drop-down list, ensure that the **Storage (general purpose v1)** option is selected.
 
     - In the **Replication** drop-down list, select the **Locally-redundant storage (LRS)** entry.
+    
+    - Click the **Advanced** tab at the top of the blade.
+    
+    - Select the **Enabled** radio button near the **Public blob access** line.
 
     - Click the **Review + Create** button, and then click **Create**.
 


### PR DESCRIPTION
A new default parameter (public access disabled) prevents the creation of the public blob access container.
I added some instruction to change the default behaviour at storage account creation.