### PR TITLE
Update Storage account creation

### DIFF
--- a/Instructions/AZ-301T04_Lab_Mod04_Deploying Messaging components to facilitate communication between Azure resources.md
+++ b/Instructions/AZ-301T04_Lab_Mod04_Deploying Messaging components to facilitate communication between Azure resources.md
@@ -121,6 +121,8 @@
     - On the **Networking** tab, ensure that the **Connectivity method** option set to **Public endpoint (all networks)**.
 
     - On the **Advanced** tab, in the **Secure transfer required** section, select the **Disabled** option.
+    
+    - On the **Advanced** tab, select **Enabled** radio button near the **Public blob access** option.
 
     - Click the **Review + create** button and then click the **Create** button.
 


### PR DESCRIPTION
A new default parameter (public access disabled) prevents the creation of the public blob access container.
I added some instruction to change the default behaviour at storage account creation.