### PR TITLE
Blob public access

### DIFF
--- a/Instructions/AZ-301T04_Lab_Mod04_Deploying Messaging components to facilitate communication between Azure resources.md
+++ b/Instructions/AZ-301T04_Lab_Mod04_Deploying Messaging components to facilitate communication between Azure resources.md
@@ -121,6 +121,8 @@
     - On the **Networking** tab, ensure that the **Connectivity method** option set to **Public endpoint (all networks)**.
 
     - On the **Advanced** tab, in the **Secure transfer required** section, select the **Disabled** option.
+    
+     - On the **Advanced** tab, in the **Blob public access** section, select the **Enabled** option.
 
     - Click the **Review + create** button and then click the **Create** button.
 


### PR DESCRIPTION
When creating the storage account for the logic app in Exercise 2 Task 1, if you don't enable the public access when you create the storage account you can't then change the container Public access level to Blobl (anonymous read access for blobs only) (Public access to this container is being blocked because public access is disabled on this storage account)