### PR TITLE
Added step to assign the automation account to the virtual machine

### DIFF
--- a/Instructions/AZ-301T02_Lab_Mod03_Deploying Configuration Management solutions to Azure.md
+++ b/Instructions/AZ-301T02_Lab_Mod03_Deploying Configuration Management solutions to Azure.md
@@ -184,7 +184,6 @@
             }
         }
     ]
-}
     ```
 
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to create a variable which value designates the name of the resource group that will contain the hub virtual network:
@@ -308,17 +307,19 @@
 
 #### Task 3: Onboard Linux VM
 
-1. Navigate back to the **LinuxAutomation - State Configuration (DSC)** blade.
+1. Navigate to **Virtual Machines** and assign the **Automation Account** under Operations / Update Management on the VM.
 
-1. Back on the **LinuxAutomation - State Configuration (DSC)** blade, click the **Nodes** link.
+2. Navigate back to the **LinuxAutomation - State Configuration (DSC)** blade.
 
-1. On the **LinuxAutomation - State configuration (DSC)** blade, click the **+ Add** button at the top of the pane.
+3. Back on the **LinuxAutomation - State Configuration (DSC)** blade, click the **Nodes** link.
 
-1. On the **Virtual Machines** blade, click the entry representing the Linux virtual machine you deployed in the previous exercise.
+4. On the **LinuxAutomation - State configuration (DSC)** blade, click the **+ Add** button at the top of the pane.
 
-1. On the virtual machine blade, click **+ Connect**.
+5. On the **Virtual Machines** blade, click the entry representing the Linux virtual machine you deployed in the previous exercise.
 
-1. On the **Registration** blade, perform the following tasks:
+6. On the virtual machine blade, click **+ Connect**.
+
+7. On the **Registration** blade, perform the following tasks:
 
     - Leave the **Registration key** setting with its default value.
 
@@ -328,21 +329,21 @@
 
     - Click the **OK** button.
 
-1. Wait for the connection process to complete before you proceed to the next step.
+8. Wait for the connection process to complete before you proceed to the next step.
 
-1. Navigate back to the **LinuxAutomation - State Configuration (DSC)** blade.
+9. Navigate back to the **LinuxAutomation - State Configuration (DSC)** blade.
 
-1. On the **LinuxAutomation - State configuration (DSC)** blade, select in the **NODE** section the virtual machine you deployed in the previous exercise.
+10. On the **LinuxAutomation - State configuration (DSC)** blade, select in the **NODE** section the virtual machine you deployed in the previous exercise.
 
     > **Note**: You may need to refresh the blade.
 
-1. On the virtual machine blade, click **Assign node configuration**.
+11. On the virtual machine blade, click **Assign node configuration**.
 
-1. On the Assign Node Configuration blade, select the node configuration **lampserver.host** and click the **OK** button.
+12. On the Assign Node Configuration blade, select the node configuration **lampserver.host** and click the **OK** button.
 
-1. Back on the **LinuxAutomation - State Configuration (DSC)** blade, click the **Refresh** button.
+13. Back on the **LinuxAutomation - State Configuration (DSC)** blade, click the **Refresh** button.
 
-1. In the list of DSC nodes, verify that the Linux virtual machine has the **Compliant** status.
+14. In the list of DSC nodes, verify that the Linux virtual machine has the **Compliant** status.
 
     > **Note**: You may need to wait for up to 30 minutes for the new status to be updated.
     

--- a/Instructions/AZ-301T04_Lab_Mod03_Deploying Network Infrastructure for use in Azure Solutions.md
+++ b/Instructions/AZ-301T04_Lab_Mod03_Deploying Network Infrastructure for use in Azure Solutions.md
@@ -123,13 +123,13 @@
 1. Within the SSH session to the Azure VM **lab08vm1**, run the following to update locally installed packages and their dependencies:
 
     ```sh
-    sudo apt-get upgrade
+    sudo apt-get update
     ```
 
 1. Within the SSH session to the Azure VM **lab08vm1**, run the following to ensure that there are no remaining updates to be processed:
 
     ```sh
-    sudo -i apt update
+    sudo -i apt upgrade
     ```
 
 1. Within the SSH session to the Azure VM **lab08vm1**, run the following to install Azure CLI: 


### PR DESCRIPTION
I added a step to the "Deploying Configuration Management solutions to Azure" Lab which describes how to assign an automation account to virtual machines. 

In "Deploying Network Infrastructure for Use in Azure Solutions" i changed the order of which apt-get command is getting executed. Update should always run before upgrade to ensure that the database and packages are up to date. 