### PR TITLE
Update AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md

### DIFF
--- a/Instructions/AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md
+++ b/Instructions/AZ-301T03_Lab_Mod03_Deploying Serverless Workloads to Azure.md
@@ -214,7 +214,7 @@
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to deploy the GitHub-resident web app code by using a local Azure Resource Manager template and a local parameters file:
 
     ```sh
-    az group deployment create --resource-group $RESOURCE_GROUP_APP --template-file github.json --parameters webAppName=webapp05022$RANDOM$RANDOM --parameters repositoryUrl=https://github.com/Azure-Samples/nodejs-docs-hello-world --parameters branch=master
+    az group deployment create --resource-group $RESOURCE_GROUP_APP --template-file github.json --parameters webAppName=$WEBAPPNAME2 --parameters repositoryUrl=https://github.com/Azure-Samples/nodejs-docs-hello-world --parameters branch=master
     ```
 
 1. Wait for the deployment to complete before you proceed to the next task.


### PR DESCRIPTION
In the original step, the CLI command creates a new webapp (using random values) and, because the default for app service plan is windows, you have an error (you cannot have a Linux app service plan and a windows app service plan in the same resource group e location).
I think that the name of the web app should be the variable WEBAPPNAME2