### PR TITLE
Update AZ-301T03_Lab_Mod02_Deploying Managed Containerized Workloads …

### DIFF
--- a/Instructions/AZ-301T03_Lab_Mod02_Deploying Managed Containerized Workloads to Azure.md
+++ b/Instructions/AZ-301T03_Lab_Mod02_Deploying Managed Containerized Workloads to Azure.md
@@ -133,7 +133,12 @@
     ```
 
     > **Note**: Make sure to use lower case letters when typing the name of the deployment. You will also receive a notification that this command is deprecated and will be removed in a future version, but successfully created the cluster.
+    
+1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to create a deployment:
 
+    ```
+    kubectl create deployment aad0402-akscluster --image=nginx --replicas=1 --port=80
+    ```
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to verify that a Kubernetes pod has been created:
 
     ```


### PR DESCRIPTION
…to Azure.md

After line #132 it missing the command to create a deployment (aka, "kubectl create deployment aad0402-akscluster --image=nginx --replicas=1 --port=80"), without creating the deployment creation you can't continue the lab, I added from line 137 to 141.

Also line #481 the version in the azuredeploy.json file, is outdated and won't work.